### PR TITLE
Fixed parcel vs. timeseries bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __*
 .idea/
 *.bak
 !HCP_1200/.gitkeep
+*.pyc

--- a/download_hcp.py
+++ b/download_hcp.py
@@ -121,15 +121,15 @@ def process_ptseries(ptseries):
 
     # Extract the cifti data into a python dictionary
     cifti_dict = {key: datum.rx2(key) for key in datum.names}
+    
+    # The key called 'Parcel' has data regarding ROI and voxel
+    roi_names = list(cifti_dict['Parcel'].names)
 
-    # The key called 'Parcel' has data regarding ROI and time series
-    parcel_dict = {key: np.asarray((cifti_dict['Parcel'].rx2(key))) 
-                   for key in cifti_dict['Parcel'].names}
+    # The key called 'data' has a 'R' object matrix 
+    # We create a dictionary with roi_names as keys and rows 
+    # of data matrix as values and return it 
 
-    # Now parcel_dict is a python dictionary with keys as roi names, and values
-    # as a np.array corresponding to time series. 
-
-    return ptseries, parcel_dict 
+    return ptseries, dict(zip(roi_names, np.asarray(cifti_dict['data']))) 
 
 
 def clean_subject(subject_id, keep_files):


### PR DESCRIPTION
Fixed the bug in the code that was discovered during Skype meeting on March 18. The `cifti_dict`s (in `process_ptseries()` function in `download_hcp.py`)  'Parcel' key holds voxel related identifier for that ROI but not the time-series data itself. The time series data was apparently associated with the 'data' key of `cifti_dict` and stored as n [R object/matrix](http://rpy.sourceforge.net/rpy2/doc-2.1/html/robjects.html#matrix) in Python. 