### PR TITLE
Replace `pickle` with `shelve`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __*
 *.bak
 !HCP_1200/.gitkeep
 !HCP_1200/meta_data.csv
+!HCP_1200/README.md
 *.pyc

--- a/HCP_1200/README.md
+++ b/HCP_1200/README.md
@@ -1,3 +1,6 @@
+The file metadata.csv contains publicly accessible metadata regarding the scans in the HCP S1200 release. In using this repository and the data contained in it you are agreeing to the Open Access Terms established by the Connectome Organization.
+
+
 # How to use shelved Py object
 
 The code on successful run should place three files called `hcp_data.dat`, `hcp_data.bak` and `hcp_data.dir` in the `HCP_1200` folder. You can access the content of these files as follows:

--- a/HCP_1200/README.md
+++ b/HCP_1200/README.md
@@ -62,6 +62,6 @@ with shelve.open('test_shelf.gdb', flag='r') as s:
     print('Existing:', s['key1'])
 ```
 
-on the Python prompt to confirm you get the error: `_gdbm.error: Reader can't store`.  If the problem is **not** fixed the output will be `Existing: new value` which the readonly flag did **not work.**. 
+on the Python prompt to confirm you get the error: `_gdbm.error: Reader can't store`.  If the problem is **not** fixed the output will be `Existing: new value` which means the readonly flag did **not work.**. 
 
 

--- a/HCP_1200/README.md
+++ b/HCP_1200/README.md
@@ -3,27 +3,26 @@
 The code on successful run should place three files called `hcp_data.dat`, `hcp_data.bak` and `hcp_data.dir` in the `HCP_1200` folder. You can access the content of these files as follows:
 
 ```python
-    import zipshelve
-    from pathlib import Path
+import zipshelve
+from pathlib import Path
+    
+fin = Path('HCP_1200/hcp_data')
 	
-    fin = Path('HCP_1200/hcp_data')
-	
-    with zipshelve.open(fin, mode='r') as shelf:
-	
-        print('Have subjects:')
-	
-	# Can also call shelf.ls() instead of for loop
-	for key in shelf.keys():
-	    print(key)
-	
-	for key, scans in shelf.items():
-	    print('\nFor subject: ' + str(key) + '\thave:')
-	    for scan, data_dict in scans.items():
-	        if scan != 'metadata':
-		    print('Scan: \t', scan)
-		    print('With ROIs:\n', '\n'.join(list(data_dict.keys())))
-	        else:
-		    print('Subject age:\t', data_dict.loc['Age'])
+with zipshelve.open(fin, mode='r') as shelf:
+    print('Have subjects:')
+
+# Can also call shelf.ls() instead of for loop
+    for key in shelf.keys():
+        print(key)
+
+    for key, scans in shelf.items():
+        print('\nFor subject: ' + str(key) + '\thave:')
+        for scan, data_dict in scans.items():
+            if scan != 'metadata':
+	        print('Scan: \t', scan)
+	        print('With ROIs:\n', '\n'.join(list(data_dict.keys())))
+            else:
+	        print('Subject age:\t', data_dict.loc['Age'])
 ```
 
 The [`shelve`](https://docs.python.org/3/library/shelve.html) module wraps around pickling, by loading only the necessary key from disk (as opposed to `pickle.load()` which would load the whole data-set into memory). We move from `pickle` to `shelve` because pickling the whole data set will likely cause memory issues. The use of disk as opposed to RAM for hold data will cause some parallelization challenges, but that is to be worked out. 

--- a/HCP_1200/README.md
+++ b/HCP_1200/README.md
@@ -2,27 +2,28 @@
 
 The code on successful run should place three files called `hcp_data.dat`, `hcp_data.bak` and `hcp_data.dir` in the `HCP_1200` folder. You can access the content of these files as follows:
 
-
-	import zipshelve
-	from pathlib import Path
+```python
+    import zipshelve
+    from pathlib import Path
 	
-	fin = Path('HCP_1200/hcp_data')
+    fin = Path('HCP_1200/hcp_data')
 	
-	with zipshelve.open(fin, mode='r') as shelf:
+    with zipshelve.open(fin, mode='r') as shelf:
 	
-	    print('Have subjects:')
+        print('Have subjects:')
 	
-	    # Can also call shelf.ls() instead of for loop
-	    for key in shelf.keys():
-	        print(key)
+	# Can also call shelf.ls() instead of for loop
+	for key in shelf.keys():
+	    print(key)
 	
-	    for key, scans in shelf.items():
-	        print('\nFor subject: ' + str(key) + '\thave:')
-	        for scan, data_dict in scans.items():
-	            if scan != 'metadata':
-	                print('Scan: \t', scan)
-	                print('With ROIs:\n', '\n'.join(list(data_dict.keys())))
-	            else:
-	                print('Subject age:\t', data_dict.loc['Age'])
+	for key, scans in shelf.items():
+	    print('\nFor subject: ' + str(key) + '\thave:')
+	    for scan, data_dict in scans.items():
+	        if scan != 'metadata':
+		    print('Scan: \t', scan)
+		    print('With ROIs:\n', '\n'.join(list(data_dict.keys())))
+	        else:
+		    print('Subject age:\t', data_dict.loc['Age'])
+```
 
 The [`shelve`](https://docs.python.org/3/library/shelve.html) module wraps around pickling, by loading only the necessary key from disk (as opposed to `pickle.load()` which would load the whole data-set into memory). We move from `pickle` to `shelve` because pickling the whole data set will likely cause memory issues. The use of disk as opposed to RAM for hold data will cause some parallelization challenges, but that is to be worked out. 

--- a/HCP_1200/README.md
+++ b/HCP_1200/README.md
@@ -1,0 +1,28 @@
+# How to use shelved Py object
+
+The code on successful run should place three files called `hcp_data.dat`, `hcp_data.bak` and `hcp_data.dir` in the `HCP_1200` folder. You can access the content of these files as follows:
+
+
+	import zipshelve
+	from pathlib import Path
+	
+	fin = Path('HCP_1200/hcp_data')
+	
+	with zipshelve.open(fin, mode='r') as shelf:
+	
+	    print('Have subjects:')
+	
+	    # Can also call shelf.ls() instead of for loop
+	    for key in shelf.keys():
+	        print(key)
+	
+	    for key, scans in shelf.items():
+	        print('\nFor subject: ' + str(key) + '\thave:')
+	        for scan, data_dict in scans.items():
+	            if scan != 'metadata':
+	                print('Scan: \t', scan)
+	                print('With ROIs:\n', '\n'.join(list(data_dict.keys())))
+	            else:
+	                print('Subject age:\t', data_dict.loc['Age'])
+
+The [`shelve`](https://docs.python.org/3/library/shelve.html) module wraps around pickling, by loading only the necessary key from disk (as opposed to `pickle.load()` which would load the whole data-set into memory). We move from `pickle` to `shelve` because pickling the whole data set will likely cause memory issues. The use of disk as opposed to RAM for hold data will cause some parallelization challenges, but that is to be worked out. 

--- a/README.md
+++ b/README.md
@@ -114,27 +114,3 @@ You may have to install a development packageis on your system for `xml2`, etc. 
 
 Alternatively, you can set up the environment using the `environment.yml` file.
 
-# How to use pickled Py object
-
-The code on successful run should place a file called `hcp_data.bin` in the `HCP_1200` folder. You can access the content of this file as follows:
-
-    import gzip, pickle
-    import numpy as np
-
-    with gzip.open('hcp_data.bin') as s:
-        data = pickle.load(s)
-
-    print('Have subjects:')
-
-    for key in data.keys():
-        print('\t' + str(key))
-
-    for key, scans in data.items():
-        print('\nFor subject: ' + str(key) + '\thave:')
-        for scan, data_dict in scans.items():
-            if scan != 'metadata':
-                print('Scan: \t', scan)
-                print('With ROIs:\n', '\n'.join(list(data_dict.keys())))
-            else:
-                print('Subject age:\t', data_dict.loc['Age'])
-

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This is  a short explanation of the inner workings of the code in this repositor
 If you have Amazon S3 and `boto` set up correctly with your credentials, you should be able to activate your environment, fire up python, and run 
 
 ```Python
-    from download_hcp import *
-    dfiles = download_subject('100610')
+from download_hcp import *
+dfiles = download_subject('100610')
 ```
 and get no errors. 
 
@@ -48,8 +48,8 @@ and get no errors.
 If you have workbench installed and correctly added to path, then in your conda environment, you should be able to fire up python and say 
 
 ```Python
-    import subprocess
-    subprocess.run(['wb_command','-help'])
+import subprocess
+subprocess.run(['wb_command','-help'])
 ```
 and get meaningful output. 
 
@@ -62,13 +62,13 @@ Prof. YMB suggested that having large amounts of RAM even with just a few cores 
 
 Note how `do_subject` really only does:
 	
-	clean_subject(idx, process_subject(*download_subject(idx)))
+```clean_subject(idx, process_subject(*download_subject(idx)))```
 
 and parallelization only involves:
 
 ```Python
-    with mp.Pool(N) as pool:
-        result = pool.map(do_subject, subject_ids)
+with mp.Pool(N) as pool:
+    result = pool.map(do_subject, subject_ids)
 ```
 where `N` is the number of parallel processes. That's so clean even I am surprised that it worked out this way.
 
@@ -80,37 +80,37 @@ where `N` is the number of parallel processes. That's so clean even I am surpris
 
 We utilize an R module in this repo. If you set up the environment using the provided .yml file, and it worked without errors you should be good. Else you need to first, install rpy2 for conda using:
 
-	conda install rpy2
+```conda install rpy2```
 
 on your environment in use. That should install the R packages needed to use R from within python. Next install the `cifti` package from CRAN:
 
 ```Python
-    # import rpy2's package module
-    import rpy2.robjects.packages as rpackages
+# import rpy2's package module
+import rpy2.robjects.packages as rpackages
 	
-    # import R's utility package
-    utils = rpackages.importr('utils')
-    utils.install_packages('cifti')
+# import R's utility package
+utils = rpackages.importr('utils')
+utils.install_packages('cifti')
 ```
 It should prompt you to pick a CRAN server for the session. If the installation is successful, it should end with
 
-	.
-	.
-	** building package indices
-	** installing vignettes
-	** testing if installed package can be loaded
-	* DONE (cifti)
+    .
+    .
+    ** building package indices
+    ** installing vignettes
+    ** testing if installed package can be loaded
+    * DONE (cifti)
 
 You can confirm successful installation by opening python and running:
 
 ```Python
-    from rpy2.robjects.packages import importr
-    importr('cifti')
+from rpy2.robjects.packages import importr
+importr('cifti')
 ```
 which should return:
  
-	>>> importr('cifti')
-	rpy2.robjects.packages.Package as a <module 'cifti'>
+    >>> importr('cifti')
+    rpy2.robjects.packages.Package as a <module 'cifti'>
 
 You may have to install a development packageis on your system for `xml2`, etc. Just use `sudo apt-get install xml2-dev` or whatever is missing. 
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,20 @@ This is  a short explanation of the inner workings of the code in this repositor
 #### Testing 1
 If you have Amazon S3 and `boto` set up correctly with your credentials, you should be able to activate your environment, fire up python, and run 
 
-	from download_hcp import *
-	    dfiles = download_subject('100610')
-	
+```Python
+    from download_hcp import *
+    dfiles = download_subject('100610')
+```
 and get no errors. 
 
 
 #### Testing 2
 If you have workbench installed and correctly added to path, then in your conda environment, you should be able to fire up python and say 
 
-	import subprocess
-	subprocess.run(['wb_command','-help'])
-	
-
+```Python
+    import subprocess
+    subprocess.run(['wb_command','-help'])
+```
 and get meaningful output. 
 
 ## Parallelizing 
@@ -65,12 +66,11 @@ Note how `do_subject` really only does:
 
 and parallelization only involves:
 
-	with mp.Pool(N) as pool:
-    	    result = pool.map(do_subject, subject_ids)
-	
-
+```Python
+    with mp.Pool(N) as pool:
+        result = pool.map(do_subject, subject_ids)
+```
 where `N` is the number of parallel processes. That's so clean even I am surprised that it worked out this way.
-
 
 ---
 
@@ -83,14 +83,15 @@ We utilize an R module in this repo. If you set up the environment using the pro
 	conda install rpy2
 
 on your environment in use. That should install the R packages needed to use R from within python. Next install the `cifti` package from CRAN:
-	
-	# import rpy2's package module
-	import rpy2.robjects.packages as rpackages
-	
-	# import R's utility package
-	utils = rpackages.importr('utils')
-	utils.install_packages('cifti')
 
+```Python
+    # import rpy2's package module
+    import rpy2.robjects.packages as rpackages
+	
+    # import R's utility package
+    utils = rpackages.importr('utils')
+    utils.install_packages('cifti')
+```
 It should prompt you to pick a CRAN server for the session. If the installation is successful, it should end with
 
 	.
@@ -101,10 +102,11 @@ It should prompt you to pick a CRAN server for the session. If the installation 
 	* DONE (cifti)
 
 You can confirm successful installation by opening python and running:
-	
-	from rpy2.robjects.packages import importr
-	importr('cifti')
-	
+
+```Python
+    from rpy2.robjects.packages import importr
+    importr('cifti')
+```
 which should return:
  
 	>>> importr('cifti')

--- a/automate.py
+++ b/automate.py
@@ -1,9 +1,9 @@
 from download_hcp import do_subject
 import multiprocessing as mp 
-import gzip, pickle
 from rpy2.robjects.packages import importr
 import zipshelve
 from pickle import HIGHEST_PROTOCOL
+from datetime import datetime
 
 
 def main():
@@ -18,32 +18,37 @@ def main():
         utils = importr('utils')
         utils.install_packages('cifti')
 
-
     with open('subjectlist.txt') as stream:
         subject_ids = stream.readlines()
 
-    
     # Strip newline characters
     subject_ids = [idx.strip() for idx in subject_ids]
+    fin = 'HCP_1200/hcp_data'
 
     # Download and process. `procs` is # of processors
     procs = 4
-    
+    print(datetime.now())
     with mp.Pool(procs) as pool:
         result = zip(subject_ids, pool.map(do_subject, subject_ids))
-    
+
     print('Shelving returned data')
-    fin = 'HCP_1200/hcp_data'
 
     with zipshelve.open(fin, protocol=HIGHEST_PROTOCOL) as shelf:
         for key, value in result:
             shelf[key] = value
 
+    print(datetime.now())
+
     # Serial instead of parallel?
 
-#    for idx in subject_ids:
-#        datum = do_subject(idx)
-#        breakpoint()
+    # datum = dict()
+    # for idx in subject_ids:
+    #     datum[idx] = do_subject(idx)
+    #
+    # with zipshelve.open(fin, protocol=HIGHEST_PROTOCOL) as shelf:
+    #     for key, value in datum:
+    #         shelf[key] = value
+
 
 
 if __name__ == "__main__":

--- a/automate.py
+++ b/automate.py
@@ -5,6 +5,7 @@ from rpy2.robjects.packages import importr
 import zipshelve
 from pickle import HIGHEST_PROTOCOL
 
+
 def main():
 
     # Read in subject list as a list

--- a/automate.py
+++ b/automate.py
@@ -2,7 +2,8 @@ from download_hcp import do_subject
 import multiprocessing as mp 
 import gzip, pickle
 from rpy2.robjects.packages import importr
-
+import zipshelve
+from pickle import HIGHEST_PROTOCOL
 
 def main():
 
@@ -28,17 +29,14 @@ def main():
     procs = 4
     
     with mp.Pool(procs) as pool:
-        result = pool.map(do_subject, subject_ids)
+        result = zip(subject_ids, pool.map(do_subject, subject_ids))
     
-    print('Pickling returned data')
+    print('Shelving returned data')
+    fin = 'HCP_1200/hcp_data'
 
-    # `result` is a list of dictionaries, but has no subject
-    # identifier so we make a new dictionary
-    
-    data = dict(zip(map(int,subject_ids), result))
-    
-    with gzip.open('HCP_1200/hcp_data.bin', 'wb') as stream:
-        pickle.dump(data, stream)
+    with zipshelve.open(fin, protocol=HIGHEST_PROTOCOL) as shelf:
+        for key, value in result:
+            shelf[key] = value
 
     # Serial instead of parallel?
 

--- a/download_hcp.py
+++ b/download_hcp.py
@@ -30,20 +30,22 @@ def download_subject(sname):
     bucket = s3.Bucket(BUCKET_NAME)
 
     # Append all keys( file names with full path) to a list
-    key_list = [str(key.key) for key in bucket.objects.filter(Prefix='HCP_1200/' + sname)]
+    key_list = (str(key.key) for key in bucket.objects.filter(Prefix='HCP_1200/' + sname))
 
     print('-'*10, ' Downloading data for ...', sname)
 
     keyword1='Atlas_MSMAll_hp2000_clean.dtseries.nii'
     keyword2='aparc.32k_fs_LR.dlabel.nii'
-    filtered_list1 = list(filter(lambda x: (keyword1 in x ), key_list))
-    filtered_list2 = list(filter(lambda x: (keyword2 in x ), key_list))
-    filtered_list = filtered_list1 + filtered_list2
+    filtered_list = filter(lambda x: (keyword1 in x or keyword2 in x), key_list)
+    dense_time_series, parcel_labels = list(), list()
+
+    # filtered_list2 = list(filter(lambda x: (keyword2 in x ), key_list))
+    # filtered_list = filtered_list1 + filtered_list2
 
     # Loop through keys and use download_file to download each key (file) to the directory where this code is running.
-    for key in filtered_list: 
+    for key in filtered_list:
         try:
-    	# Respect the directory structure
+            # Respect the directory structure
             os.makedirs(os.path.dirname(key), exist_ok=True)
             if not Path(key).is_file():
                 s3.Bucket(BUCKET_NAME).download_file(key, key)
@@ -55,8 +57,15 @@ def download_subject(sname):
             else:
                 raise KeyError
 
-   #return dense_time_series, parcellation_labels, subject name
-    return filtered_list1, filtered_list2, sname
+        if keyword1 in key:
+            dense_time_series.append(key)
+        elif keyword2 in key:
+            parcel_labels.append(key)
+        else:
+            raise LookupError
+
+    # return dense_time_series, parcellation_labels, subject name
+    return dense_time_series, parcel_labels, sname
 
 
 def process_subject(dtseries, dlabels, sid):
@@ -109,7 +118,6 @@ def du(path):
         return subprocess.check_output(['du','-sh', path]).split()[0].decode('utf-8')
     else:
         return subprocess.check_output(['powershell', win_string])
-
 
 
 def process_ptseries(ptseries):

--- a/zipshelve.py
+++ b/zipshelve.py
@@ -67,29 +67,35 @@ class ZipShelf(shelve.Shelf):
             if os.path.exists(filename) and 'r' == mode:
                 # gunzip into temporary location
                 filename_ = self._gunzip(filename)
+
                 if not os.path.exists(filename_):
                     raise TypeError("Unable to gunzip properly: %s" % filename)
+
                 if not self.__silent:
                     size1 = os.path.getsize(filename)
                     size2 = os.path.getsize(filename_)
                     logger.info("GZIP uncompression %s: %.1f%%" % (filename, (size2 * 100.0) / size1))
-                filename = filename_
+#                filename = filename_
                 self.__filename = filename_
                 self.__remove = True
             elif os.path.exists(filename) and 'r' != mode:
-                # unzip in place
                 filename_ = filename[:-3]
-                # remove existing file (if needed) 
-                if os.path.exists(filename_): os.remove(filename_)
+
+                # remove existing file (if needed)
+                if os.path.exists(filename_):
+                    os.remove(filename_)
                 size1 = os.path.getsize(filename)
-                # gunzip in place 
+
+                # gunzip in place
                 self.__in_place_gunzip(filename)
+
                 if not os.path.exists(filename_):
                     raise TypeError("Unable to gunzip properly: %s" % filename)
+
                 if not self.__silent:
                     size2 = os.path.getsize(filename_)
                     logger.info("GZIP uncompression %s: %.1f%%" % (filename, (size2 * 100.0) / size1))
-                filename = filename_
+#                filename = filename_
                 self.__gzip = True
                 self.__filename = filename_
                 self.__remove = False
@@ -157,12 +163,14 @@ class ZipShelf(shelve.Shelf):
         if self.__gzip and os.path.exists(self.__filename):
             # get the initial size 
             size1 = os.path.getsize(self.__filename)
+
             # gzip the file
             self.__in_place_gzip(self.__filename)
             
             if not os.path.exists(self.__filename + '.gz'):
                 logger.warning('Unable to compress the file %s ' % self.__filename)
             size2 = os.path.getsize(self.__filename + '.gz')
+
             if not self.__silent:
                 logger.info('GZIP compression %s: %.1f%%' % (self.__filename, (size2 * 100.0) / size1))
 
@@ -201,7 +209,8 @@ class ZipShelf(shelve.Shelf):
         
         """
         filename = filein[:-3]
-        if os.path.exists(filename): os.remove(filename)
+        if os.path.exists(filename):
+            os.remove(filename)
 
         # gunzip the file 
         fileout = self._gunzip(filein)
@@ -224,7 +233,7 @@ class ZipShelf(shelve.Shelf):
         if not os.path.exists(filein):
             raise NameError("GZIP: non existing file: " + filein)
 
-        import tempfile, gzip
+        import tempfile, gzip, time
 
         fin = file(filein, 'r')
         fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb.gz')
@@ -236,7 +245,6 @@ class ZipShelf(shelve.Shelf):
         finally:
             fout.close()
             fin.close()
-            import time
             time.sleep(3)
         return fileout
 
@@ -248,7 +256,7 @@ class ZipShelf(shelve.Shelf):
         if not os.path.exists(filein):
             raise NameError("GUNZIP: non existing file: " + filein)
 
-        import gzip, tempfile
+        import gzip, tempfile, time
 
         fin = gzip.open(filein, 'r')
         fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb')
@@ -260,7 +268,6 @@ class ZipShelf(shelve.Shelf):
         finally:
             fout.close()
             fin.close()
-            import time
             time.sleep(3)
         return fileout
 
@@ -299,7 +306,7 @@ def _zip_setitem(self, key, value):
     f = BytesIO()
     p = Pickler(f, self._protocol)
     p.dump(value)
-    self.dict[key] = zlib.compress(f.getvalue(), self.compresslevel)
+    self.dict[key] = zlib.compress(f.getvalue(), self.compress_level)
 
 
 ZipShelf.__getitem__ = _zip_getitem

--- a/zipshelve.py
+++ b/zipshelve.py
@@ -4,7 +4,7 @@
 # =============================================================================
 """ This is zip-version of shelve database.
 
-Keeping the same interface and functionlity as shelve data base,
+Keeping the same interface and functionality as shelve data base,
 ZipShelf allows much more compact file size through the on-flight
 compression of the content
 
@@ -12,184 +12,162 @@ However is contains several new features:
 
  - Optionally it is possible to perform the compression
    of the whole data base, that can be rathe useful fo data base
-   with large amout of keys 
+   with large amount of keys
 """
 # =============================================================================
-__author__  = "Vanya BELYAEV Ivan.Belyaev@itep.ru"
-__date__    = "2010-04-30"
-__version__ = "$Revision$" 
+__author__ = "Vanya BELYAEV Ivan.Belyaev@itep.ru"
+__date__ = "2010-04-30"
+__version__ = "$Revision$"
 # =============================================================================
 
-__all__ = (
-    'ZipShelf' ,   ## The DB-itself
-    'open'     ,   ## helper function to hide the actual DB
-    'tmpdb'    ,   ## create TEMPORARY data base 
-    )
+__all__ = ('ZipShelf', 'open', 'tmpdb')
 
 try:
     from cPickle import Pickler, Unpickler, HIGHEST_PROTOCOL
 except ImportError:
-    from  pickle import Pickler, Unpickler, HIGHEST_PROTOCOL 
+    from pickle import Pickler, Unpickler, HIGHEST_PROTOCOL
 
 # ==============================================================================
 import os
-import zlib        ## use zlib to compress DB-content 
-import shelve      ## 
+import zlib  # use zlib to compress DB-content
+import shelve
 import shutil
-from io import BytesIO 
+from io import BytesIO
 import logging as logger
+
+
 # =============================================================================
 
 
 class ZipShelf(shelve.Shelf):
     """
     Zipped-version of ``shelve''-database     
-    """    
-    def __init__(
-        self                                   ,
-        filename                               ,
-        mode      = 'c'                        , 
-        protocol  = HIGHEST_PROTOCOL           , 
-        compress  = zlib.Z_BEST_COMPRESSION    ,
-        writeback = False                      ,
-        silent    = False                      ) :
+    """
+
+    def __init__(self, filename,  mode='c', protocol=HIGHEST_PROTOCOL, compress=zlib.Z_BEST_COMPRESSION,
+                 writeback=False, silent=False):
 
         # expand the actual file name 
-        filename  = os.path.expandvars ( filename )
-        filename  = os.path.expanduser ( filename )
-        filename  = os.path.expandvars ( filename )
-        filename  = os.path.expandvars ( filename )
+        filename = os.path.expandvars(filename)
+        filename = os.path.expanduser(filename)
+        filename = os.path.expandvars(filename)
+        filename = os.path.expandvars(filename)
 
-        self.__gzip          = False 
-        self.__filename      = filename
-        self.__remove        = False
-        self.__silent        = silent
-        self.__opened        = False 
+        self.__gzip = False
+        self.__filename = filename
+        self.__remove = False
+        self.__silent = silent
+        self.__opened = False
 
-        if not self.__silent :
-            logger.info ( 'Open DB: %s' % filename ) 
-        
+        if not self.__silent:
+            logger.info('Open DB: %s' % filename)
+
         if filename.rfind('.gz') + 3 == len(filename):
-            
-            if os.path.exists ( filename ) and 'r' == mode :
-                ## gunzip into temporary location
-                filename_ = self._gunzip ( filename ) 
-                if not os.path.exists ( filename_ ) :
-                    raise TypeError ( "Unable to gunzip properly: %s" % filename )
-                if not self.__silent : 
-                    size1 = os.path.getsize ( filename  ) 
-                    size2 = os.path.getsize ( filename_ )
-                    logger.info("GZIP uncompression %s: %.1f%%" %  ( filename , (size2*100.0)/size1 ) )
-                filename        = filename_ 
+
+            if os.path.exists(filename) and 'r' == mode:
+                # gunzip into temporary location
+                filename_ = self._gunzip(filename)
+                if not os.path.exists(filename_):
+                    raise TypeError("Unable to gunzip properly: %s" % filename)
+                if not self.__silent:
+                    size1 = os.path.getsize(filename)
+                    size2 = os.path.getsize(filename_)
+                    logger.info("GZIP uncompression %s: %.1f%%" % (filename, (size2 * 100.0) / size1))
+                filename = filename_
                 self.__filename = filename_
-                self.__remove   = True
-            elif os.path.exists ( filename ) and 'r' != mode :
-                ## unzip in place
-                filename_     = filename[:-3]
+                self.__remove = True
+            elif os.path.exists(filename) and 'r' != mode:
+                # unzip in place
+                filename_ = filename[:-3]
                 # remove existing file (if needed) 
-                if os.path.exists ( filename_ ) : os.remove ( filename_ )
-                size1 = os.path.getsize ( filename  ) 
+                if os.path.exists(filename_): os.remove(filename_)
+                size1 = os.path.getsize(filename)
                 # gunzip in place 
-                self.__in_place_gunzip  ( filename ) 
-                ##
-                if not os.path.exists ( filename_ ) :
-                    raise TypeError ( "Unable to gunzip properly: %s" % filename )
-                if not self.__silent : 
-                    size2 = os.path.getsize ( filename_ )
-                    logger.info("GZIP uncompression %s: %.1f%%" %  ( filename , (size2*100.0)/size1 ) ) 
-                filename        = filename_ 
-                self.__gzip     = True 
+                self.__in_place_gunzip(filename)
+                if not os.path.exists(filename_):
+                    raise TypeError("Unable to gunzip properly: %s" % filename)
+                if not self.__silent:
+                    size2 = os.path.getsize(filename_)
+                    logger.info("GZIP uncompression %s: %.1f%%" % (filename, (size2 * 100.0) / size1))
+                filename = filename_
+                self.__gzip = True
                 self.__filename = filename_
-                self.__remove   = False
-            else : 
-                ## 
-                filename        = filename[:-3]
-                self.__gzip     = True 
+                self.__remove = False
+            else:
+                filename = filename[:-3]
+                self.__gzip = True
                 self.__filename = filename
 
         import dbm
-        shelve.Shelf.__init__ (
-            self                                   ,
-            dbm.open ( self.__filename , mode ) ,
-            protocol                               ,
-            writeback                              )
-        
-        self.compresslevel = compress
-        self.__opened      = True
+        shelve.Shelf.__init__(self, dbm.open(self.__filename, mode), protocol, writeback)
+        self.compress_level = compress
+        self.__opened = True
 
-    def filename ( self ) : return self.__filename
-    
-    ## destructor 
-    def __del__ ( self ) :
+    def filename(self):
+        return self.__filename
+
+    # destructor
+    def __del__(self):
         """
         Destructor 
         """
-        if self.__opened : self.close()  
+        if self.__opened:
+            self.close()
 
-    ## list the avilable keys 
-    def __dir ( self , pattern = '' ) :
+    # list the available keys
+    def __dir(self, pattern=''):
         """
-        List the avilable keys (patterns included).
-        Pattern matching is performed accoriding to
-        fnmatch/glob/shell rules [it is not regex!] 
-        
-        >>> db = ...
-        >>> db.ls() ## all keys
-        >>> db.ls ('*MC*')
-        
+        List the available keys (patterns included). Pattern matching is performed according to
+        fnmatch/glob/shell rules [it is not regex!]
         """
         keys_ = self.keys()
         keys_.sort()
-        if pattern :
+        if pattern:
             import fnmatch
-            _keys = [ k for k in keys_ if fnmatch.fnmatchcase ( k , pattern ) ]
+            _keys = [k for k in keys_ if fnmatch.fnmatchcase(k, pattern)]
             keys_ = _keys
-        #
-        for key in keys_ : print(key)
-        
-    ## list the avilable keys 
-    def ls    ( self , pattern = '' ) :
-        """
-        List the avilable keys (patterns included).
-        Pattern matching is performed accoriding to
-        fnmatch/glob/shell rules [it is not regex!] 
 
-        >>> db = ...
-        >>> db.ls() ## all keys
-        >>> db.ls ('*MC*')        
-        
+        for key in keys_:
+            print(key)
+
+    # list the available keys - alias
+    def ls(self, pattern=''):
         """
-        return self.__dir( pattern )
-        
-    ## cloze and gzip (if needed)
-    def close ( self ) :
+        List the available keys (patterns included). Pattern matching is performed accoriding to
+        fnmatch/glob/shell rules [it is not regex!]
+        """
+        return self.__dir(pattern)
+
+    # close and gzip (if needed)
+    def close(self):
         """
         Close the file (and gzip it if required) 
         """
-        if not self.__opened : return 
-        ##
-        shelve.Shelf.close ( self )
-        self.__opened = False  
-        ##
-        if self.__remove and os.path.exists ( self.__filename ) :
-            if not self.__silent :
-                logger.info( 'REMOVE: ', self.__filename )
-            os.remove ( self.__filename )
-        ##
-        if self.__gzip and os.path.exists ( self.__filename ) :
-            # get the initial size 
-            size1 = os.path.getsize ( self.__filename )
-            # gzip the file
-            self.__in_place_gzip ( self.__filename ) 
-            #
-            if not os.path.exists ( self.__filename + '.gz' ) :
-                logger.warning( 'Unable to compress the file %s ' % self.__filename  )
-            size2 = os.path.getsize( self.__filename + '.gz' )
-            if not self.__silent : 
-                logger.info( 'GZIP compression %s: %.1f%%' % ( self.__filename, (size2*100.0)/size1 ) ) 
+        if not self.__opened:
+            return
 
-    ## gzip the file (``in-place'') 
-    def __in_place_gzip   ( self , filein ) :
+        shelve.Shelf.close(self)
+        self.__opened = False
+
+        if self.__remove and os.path.exists(self.__filename):
+            if not self.__silent:
+                logger.info('REMOVE: ', self.__filename)
+            os.remove(self.__filename)
+
+        if self.__gzip and os.path.exists(self.__filename):
+            # get the initial size 
+            size1 = os.path.getsize(self.__filename)
+            # gzip the file
+            self.__in_place_gzip(self.__filename)
+            
+            if not os.path.exists(self.__filename + '.gz'):
+                logger.warning('Unable to compress the file %s ' % self.__filename)
+            size2 = os.path.getsize(self.__filename + '.gz')
+            if not self.__silent:
+                logger.info('GZIP compression %s: %.1f%%' % (self.__filename, (size2 * 100.0) / size1))
+
+    # gzip the file (``in-place'')
+    def __in_place_gzip(self, filein):
         """
         Gzip the file ``in-place''
         
@@ -197,23 +175,24 @@ class ZipShelf(shelve.Shelf):
         but it does not work properly for multiprocessing environemnt
         
         """
-        if os.path.exists ( filein + '.gz' ) : os.remove ( filein + '.gz' )
-        #
+        if os.path.exists(filein + '.gz'):
+            os.remove(filein + '.gz')
+        
         # gzip the file 
-        fileout = self._gzip ( filein )
-        # 
-        if os.path.exists ( fileout ) :
+        fileout = self._gzip(filein)
+         
+        if os.path.exists(fileout):
             # rename the temporary file 
-            shutil.move ( fileout , filein + '.gz' )
-            #
+            shutil.move(fileout, filein + '.gz')
+            
             import time
-            time.sleep( 3 )
-            #
+            time.sleep(3)
+            
             # remove the original
-            os.remove   ( filein ) 
+            os.remove(filein)
 
-    ## gunzip the file (``in-place'') 
-    def __in_place_gunzip   ( self , filein ) :
+    # gunzip the file (``in-place'')
+    def __in_place_gunzip(self, filein):
         """
         Gunzip the file ``in-place''
         
@@ -221,81 +200,81 @@ class ZipShelf(shelve.Shelf):
         but unfortunately it does not work properly for multithreaded environemnt
         
         """
-        #
-        filename = filein[:-3]            
-        if os.path.exists ( filename ) : os.remove ( filename )
-        #
-        # gunzip the file 
-        fileout = self._gunzip ( filein )
-        #        
-        if os.path.exists ( fileout ) :
-            # rename the temporary file 
-            shutil.move ( fileout , filename )
-            #
-            import time
-            time.sleep( 3 )
-            #
-            # remove the original
-            os.remove   ( filein ) 
+        filename = filein[:-3]
+        if os.path.exists(filename): os.remove(filename)
 
-    ## gzip the file into temporary location, keep original
-    def _gzip   ( self , filein ) :
+        # gunzip the file 
+        fileout = self._gunzip(filein)
+                
+        if os.path.exists(fileout):
+            # rename the temporary file 
+            shutil.move(fileout, filename)
+            
+            import time
+            time.sleep(3)
+            
+            # remove the original
+            os.remove(filein)
+
+    # gzip the file into temporary location, keep original
+    def _gzip(self, filein):
         """
         Gzip the file into temporary location, keep original
         """
-        if not os.path.exists  ( filein  ) :
-            raise NameError ( "GZIP: non existing file: " + filein )
-        #
-        fin  =      file ( filein  , 'r' )
-        #
-        import tempfile 
-        fd,fileout = tempfile.mkstemp ( prefix = 'tmp_' , suffix = '_zdb.gz' )
-        #
-        import gzip 
-        fout = gzip.open ( fileout , 'w' )
-        #
-        try : 
-            for all in fin : fout.write ( all )
+        if not os.path.exists(filein):
+            raise NameError("GZIP: non existing file: " + filein)
+
+        import tempfile, gzip
+
+        fin = file(filein, 'r')
+        fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb.gz')
+        fout = gzip.open(fileout, 'w')
+
+        try:
+            for all in fin:
+                fout.write(all)
         finally:
             fout.close()
-            fin .close()   
+            fin.close()
             import time
-            time.sleep( 3 ) 
+            time.sleep(3)
         return fileout
-        
-    ## gzip the file into temporary location, keep original
-    def _gunzip ( self , filein ) :
+
+    # gunzip the file into temporary location, keep original
+    def _gunzip(self, filein):
         """
         Gunzip the file into temporary location, keep original
         """
-        if not os.path.exists  ( filein  ) :
-            raise NameError ( "GUNZIP: non existing file: " + filein )
-        #
-        import gzip 
-        fin  = gzip.open ( filein  , 'r' )
-        #
-        import tempfile 
-        fd,fileout = tempfile.mkstemp ( prefix = 'tmp_' , suffix = '_zdb' )
-        fout = file ( fileout , 'w' )
-        #
-        try : 
-            for all in fin : fout.write ( all )
-        finally: 
+        if not os.path.exists(filein):
+            raise NameError("GUNZIP: non existing file: " + filein)
+
+        import gzip, tempfile
+
+        fin = gzip.open(filein, 'r')
+        fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb')
+        fout = file(fileout, 'w')
+
+        try:
+            for all in fin:
+                fout.write(all)
+        finally:
             fout.close()
-            fin .close()
+            fin.close()
             import time
-            time.sleep( 3 ) 
+            time.sleep(3)
         return fileout
 
-    #
-    ## some context manager functionality
-    # 
-    def __enter__ ( self      ) : return self 
-    def __exit__  ( self , *_ ) : self.close ()
-        
+    # some context manager functionality
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
 # =============================================================================
-## ``get-and-uncompress-item'' from dbase 
-def _zip_getitem (self, key):
+# ``get-and-uncompress-item'' from dbase
+def _zip_getitem(self, key):
     """
     ``get-and-uncompress-item'' from dbase 
     """
@@ -308,9 +287,10 @@ def _zip_getitem (self, key):
             self.cache[key] = value
     return value
 
+
 # =============================================================================
-## ``set-and-compress-item'' to dbase 
-def _zip_setitem ( self , key , value ) :
+# ``set-and-compress-item'' to dbase
+def _zip_setitem(self, key, value):
     """
     ``set-and-compress-item'' to dbase 
     """
@@ -319,21 +299,18 @@ def _zip_setitem ( self , key , value ) :
     f = BytesIO()
     p = Pickler(f, self._protocol)
     p.dump(value)
-    self.dict[key] = zlib.compress( f.getvalue(), self.compresslevel)
+    self.dict[key] = zlib.compress(f.getvalue(), self.compresslevel)
+
 
 ZipShelf.__getitem__ = _zip_getitem
 ZipShelf.__setitem__ = _zip_setitem
 
+
 # =============================================================================
-## helper finction to access ZipShelve data base#
-#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
-#  @date   2010-04-30
-def open ( filename                                   ,
-           mode          = 'c'                        ,
-           protocol      = HIGHEST_PROTOCOL           ,
-           compresslevel = zlib.Z_BEST_COMPRESSION    , 
-           writeback     = False                      ,
-           silent        = True                       ) : 
+# helper finction to access ZipShelve data base
+
+def open(filename, mode='c', protocol=HIGHEST_PROTOCOL, compress_level=zlib.Z_BEST_COMPRESSION,
+         writeback=False, silent=True):
     """
     Open a persistent dictionary for reading and writing.
     
@@ -346,61 +323,46 @@ def open ( filename                                   ,
     
     See the module's __doc__ string for an overview of the interface.
     """
-    
-    return ZipShelf ( filename      ,
-                      mode          ,
-                      protocol      ,
-                      compresslevel ,
-                      writeback     ,
-                      silent        )
 
-
+    return ZipShelf(filename, mode, protocol, compress_level, writeback, silent)
 
 # =============================================================================
-## TEMPORARY Zipped-version of ``shelve''-database
-#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
-#  @date   2015-10-31
+# TEMPORARY Zipped-version of ``shelve''-database
+
+
 class TmpZipShelf(ZipShelf):
     """
     TEMPORARY Zipped-version of ``shelve''-database     
-    """    
-    def __init__(
-        self                                   ,
-        protocol  = HIGHEST_PROTOCOL           , 
-        compress  = zlib.Z_BEST_COMPRESSION    ,
-        silent    = False                      ) :
+    """
 
-        ## create temporary file name 
+    def __init__(self, protocol=HIGHEST_PROTOCOL, compress=zlib.Z_BEST_COMPRESSION, silent=False):
+
+        # create temporary file name
         import tempfile
-        filename = tempfile.mktemp  ( suffix = '.zdb' )
-        
-        ZipShelf.__init__ ( self     ,  
-                            filename ,
-                            'n'      ,
-                            protocol ,
-                            compress , 
-                            False    , ## writeback 
-                            silent   ) 
-        
-    ## close and delete the file 
-    def close ( self )  :
-        ## close the shelve file
-        fname = self.filename() 
-        ZipShelf.close ( self )
-        ## delete the file 
-        if os.path.exists ( fname ) :
-            try :
-                os.unlink ( fname )
-            except : 
+        filename = tempfile.mktemp(suffix='.zdb')
+
+        ZipShelf.__init__(self, filename, 'n', protocol, compress, False, silent)
+
+        # close and delete the file
+
+    def close(self):
+        # close the shelve file
+        fname = self.filename()
+        ZipShelf.close(self)
+
+        # delete the file
+        if os.path.exists(fname):
+            try:
+                os.unlink(fname)
+            except:
                 pass
-            
+
+
 # =============================================================================
-## helper finction to open TEMPORARY ZipShelve data base#
-#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
-#  @date   2010-04-30
-def tmpdb ( protocol      = HIGHEST_PROTOCOL           ,
-            compresslevel = zlib.Z_BEST_COMPRESSION    , 
-            silent        = True                       ) : 
+# helper finction to open TEMPORARY ZipShelve data base
+
+
+def tmpdb(protocol=HIGHEST_PROTOCOL, compress_level=zlib.Z_BEST_COMPRESSION, silent=True):
     """
     Open a TEMPORARY persistent dictionary for reading and writing.
     
@@ -409,30 +371,21 @@ def tmpdb ( protocol      = HIGHEST_PROTOCOL           ,
     
     See the module's __doc__ string for an overview of the interface.
     """
-    return TmpZipShelf ( protocol      ,
-                         compresslevel ,
-                         silent        )
-    
+    return TmpZipShelf(protocol,compress_level, silent)
 
-# ============================================================================
-# logger.debug ( "Simple generic (c)Pickle-based ``zipped''-database")
-# =============================================================================
-## a bit more decorations for shelve  (optional)
-# import Ostap.shelve_ext
 
 # =============================================================================
-if '__main__' == __name__ :
-    
-    logger.info ( __file__  + '\n' ) 
-    logger.info ( 80*'*'   )
-    logger.info ( __doc__  )
-    logger.info ( 80*'*' )
-    logger.info ( ' Author  : %s' %         __author__    ) 
-    logger.info ( ' Version : %s' %         __version__   ) 
-    logger.info ( ' Date    : %s' %         __date__      )
-    logger.info ( ' Symbols : %s' %  list ( __all__     ) )
-    logger.info ( 80*'*' ) 
-    
+if '__main__' == __name__:
+    logger.info(__file__ + '\n')
+    logger.info(80 * '*')
+    logger.info(__doc__)
+    logger.info(80 * '*')
+    logger.info(' Author  : %s' % __author__)
+    logger.info(' Version : %s' % __version__)
+    logger.info(' Date    : %s' % __date__)
+    logger.info(' Symbols : %s' % list(__all__))
+    logger.info(80 * '*')
+
 # =============================================================================
 # The END 
 # =============================================================================

--- a/zipshelve.py
+++ b/zipshelve.py
@@ -245,19 +245,6 @@ class ZipShelf(shelve.Shelf):
         return fileout
 
 
-#        fin = file(filein, 'r')
-#        fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb.gz')
-#        fout = gzip.open(fileout, 'w')
-#
-#        try:
-#            for all in fin:
-#                fout.write(all)
-#        finally:
-#            fout.close()
-#            fin.close()
-#            time.sleep(3)
-#        return fileout
-
     # gunzip the file into temporary location, keep original
     def _gunzip(self, filein):
         """
@@ -279,19 +266,6 @@ class ZipShelf(shelve.Shelf):
 
         return fileout
 
-
-#        fin = gzip.open(filein, 'r')
-#        fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb')
-#        fout = file(fileout, 'w')
-#
-#        try:
-#            for all in fin:
-#                fout.write(all)
-#        finally:
-#            fout.close()
-#            fin.close()
-#            time.sleep(3)
-#        return fileout
 
     # some context manager functionality
     def __enter__(self):

--- a/zipshelve.py
+++ b/zipshelve.py
@@ -4,7 +4,7 @@
 # =============================================================================
 """ This is zip-version of shelve database.
 
-Keeping the same interface and functionlity as shelve data base,
+Keeping the same interface and functionality as shelve data base,
 ZipShelf allows much more compact file size through the on-flight
 compression of the content
 
@@ -12,184 +12,163 @@ However is contains several new features:
 
  - Optionally it is possible to perform the compression
    of the whole data base, that can be rathe useful fo data base
-   with large amout of keys 
+   with large amount of keys
 """
 # =============================================================================
-__author__  = "Vanya BELYAEV Ivan.Belyaev@itep.ru"
-__date__    = "2010-04-30"
-__version__ = "$Revision$" 
+__author__ = "Vanya BELYAEV Ivan.Belyaev@itep.ru"
+__date__ = "2010-04-30"
+__version__ = "$Revision$"
 # =============================================================================
 
-__all__ = (
-    'ZipShelf' ,   ## The DB-itself
-    'open'     ,   ## helper function to hide the actual DB
-    'tmpdb'    ,   ## create TEMPORARY data base 
-    )
+__all__ = ('ZipShelf', 'open', 'tmpdb')
 
 try:
     from cPickle import Pickler, Unpickler, HIGHEST_PROTOCOL
 except ImportError:
-    from  pickle import Pickler, Unpickler, HIGHEST_PROTOCOL 
+    from pickle import Pickler, Unpickler, HIGHEST_PROTOCOL
 
 # ==============================================================================
 import os
-import zlib        ## use zlib to compress DB-content 
-import shelve      ## 
+import zlib  # use zlib to compress DB-content
+import shelve
 import shutil
-from io import BytesIO 
+from io import BytesIO
 import logging as logger
+
+
 # =============================================================================
 
 
 class ZipShelf(shelve.Shelf):
     """
     Zipped-version of ``shelve''-database     
-    """    
-    def __init__(
-        self                                   ,
-        filename                               ,
-        mode      = 'c'                        , 
-        protocol  = HIGHEST_PROTOCOL           , 
-        compress  = zlib.Z_BEST_COMPRESSION    ,
-        writeback = False                      ,
-        silent    = False                      ) :
+    """
+
+    def __init__(self, filename,  mode='c', protocol=HIGHEST_PROTOCOL, compress=zlib.Z_BEST_COMPRESSION,
+                 writeback=False, silent=False):
 
         # expand the actual file name 
-        filename  = os.path.expandvars ( filename )
-        filename  = os.path.expanduser ( filename )
-        filename  = os.path.expandvars ( filename )
-        filename  = os.path.expandvars ( filename )
+        filename = os.path.expandvars(filename)
+        filename = os.path.expanduser(filename)
+        filename = os.path.expandvars(filename)
+        filename = os.path.expandvars(filename)
 
-        self.__gzip          = False 
-        self.__filename      = filename
-        self.__remove        = False
-        self.__silent        = silent
-        self.__opened        = False 
+        self.__gzip = False
+        self.__filename = filename
+        self.__remove = False
+        self.__silent = silent
+        self.__opened = False
 
-        if not self.__silent :
-            logger.info ( 'Open DB: %s' % filename ) 
-        
+        if not self.__silent:
+            logger.info('Open DB: %s' % filename)
+
         if filename.rfind('.gz') + 3 == len(filename):
-            
-            if os.path.exists ( filename ) and 'r' == mode :
-                ## gunzip into temporary location
-                filename_ = self._gunzip ( filename ) 
-                if not os.path.exists ( filename_ ) :
-                    raise TypeError ( "Unable to gunzip properly: %s" % filename )
-                if not self.__silent : 
-                    size1 = os.path.getsize ( filename  ) 
-                    size2 = os.path.getsize ( filename_ )
-                    logger.info("GZIP uncompression %s: %.1f%%" %  ( filename , (size2*100.0)/size1 ) )
-                filename        = filename_ 
+
+            if os.path.exists(filename) and 'r' == mode:
+                # gunzip into temporary location
+                filename_ = self._gunzip(filename)
+                if not os.path.exists(filename_):
+                    raise TypeError("Unable to gunzip properly: %s" % filename)
+                if not self.__silent:
+                    size1 = os.path.getsize(filename)
+                    size2 = os.path.getsize(filename_)
+                    logger.info("GZIP uncompression %s: %.1f%%" % (filename, (size2 * 100.0) / size1))
+                filename = filename_
                 self.__filename = filename_
-                self.__remove   = True
-            elif os.path.exists ( filename ) and 'r' != mode :
-                ## unzip in place
-                filename_     = filename[:-3]
+                self.__remove = True
+            elif os.path.exists(filename) and 'r' != mode:
+                # unzip in place
+                filename_ = filename[:-3]
                 # remove existing file (if needed) 
-                if os.path.exists ( filename_ ) : os.remove ( filename_ )
-                size1 = os.path.getsize ( filename  ) 
+                if os.path.exists(filename_): os.remove(filename_)
+                size1 = os.path.getsize(filename)
                 # gunzip in place 
-                self.__in_place_gunzip  ( filename ) 
-                ##
-                if not os.path.exists ( filename_ ) :
-                    raise TypeError ( "Unable to gunzip properly: %s" % filename )
-                if not self.__silent : 
-                    size2 = os.path.getsize ( filename_ )
-                    logger.info("GZIP uncompression %s: %.1f%%" %  ( filename , (size2*100.0)/size1 ) ) 
-                filename        = filename_ 
-                self.__gzip     = True 
+                self.__in_place_gunzip(filename)
+                if not os.path.exists(filename_):
+                    raise TypeError("Unable to gunzip properly: %s" % filename)
+                if not self.__silent:
+                    size2 = os.path.getsize(filename_)
+                    logger.info("GZIP uncompression %s: %.1f%%" % (filename, (size2 * 100.0) / size1))
+                filename = filename_
+                self.__gzip = True
                 self.__filename = filename_
-                self.__remove   = False
-            else : 
+                self.__remove = False
+            else:
                 ## 
-                filename        = filename[:-3]
-                self.__gzip     = True 
+                filename = filename[:-3]
+                self.__gzip = True
                 self.__filename = filename
 
         import dbm
-        shelve.Shelf.__init__ (
-            self                                   ,
-            dbm.open ( self.__filename , mode ) ,
-            protocol                               ,
-            writeback                              )
-        
-        self.compresslevel = compress
-        self.__opened      = True
+        shelve.Shelf.__init__(self, dbm.open(self.__filename, mode), protocol, writeback)
+        self.compress_level = compress
+        self.__opened = True
 
-    def filename ( self ) : return self.__filename
-    
-    ## destructor 
-    def __del__ ( self ) :
+    def filename(self):
+        return self.__filename
+
+    # destructor
+    def __del__(self):
         """
         Destructor 
         """
-        if self.__opened : self.close()  
+        if self.__opened:
+            self.close()
 
-    ## list the avilable keys 
-    def __dir ( self , pattern = '' ) :
+    # list the available keys
+    def __dir(self, pattern=''):
         """
-        List the avilable keys (patterns included).
-        Pattern matching is performed accoriding to
-        fnmatch/glob/shell rules [it is not regex!] 
-        
-        >>> db = ...
-        >>> db.ls() ## all keys
-        >>> db.ls ('*MC*')
-        
+        List the available keys (patterns included). Pattern matching is performed according to
+        fnmatch/glob/shell rules [it is not regex!]
         """
         keys_ = self.keys()
         keys_.sort()
-        if pattern :
+        if pattern:
             import fnmatch
-            _keys = [ k for k in keys_ if fnmatch.fnmatchcase ( k , pattern ) ]
+            _keys = [k for k in keys_ if fnmatch.fnmatchcase(k, pattern)]
             keys_ = _keys
-        #
-        for key in keys_ : print(key)
-        
-    ## list the avilable keys 
-    def ls    ( self , pattern = '' ) :
-        """
-        List the avilable keys (patterns included).
-        Pattern matching is performed accoriding to
-        fnmatch/glob/shell rules [it is not regex!] 
 
-        >>> db = ...
-        >>> db.ls() ## all keys
-        >>> db.ls ('*MC*')        
-        
+        for key in keys_:
+            print(key)
+
+    # list the available keys - alias
+    def ls(self, pattern=''):
         """
-        return self.__dir( pattern )
-        
-    ## cloze and gzip (if needed)
-    def close ( self ) :
+        List the available keys (patterns included). Pattern matching is performed accoriding to
+        fnmatch/glob/shell rules [it is not regex!]
+        """
+        return self.__dir(pattern)
+
+    # close and gzip (if needed)
+    def close(self):
         """
         Close the file (and gzip it if required) 
         """
-        if not self.__opened : return 
-        ##
-        shelve.Shelf.close ( self )
-        self.__opened = False  
-        ##
-        if self.__remove and os.path.exists ( self.__filename ) :
-            if not self.__silent :
-                logger.info( 'REMOVE: ', self.__filename )
-            os.remove ( self.__filename )
-        ##
-        if self.__gzip and os.path.exists ( self.__filename ) :
-            # get the initial size 
-            size1 = os.path.getsize ( self.__filename )
-            # gzip the file
-            self.__in_place_gzip ( self.__filename ) 
-            #
-            if not os.path.exists ( self.__filename + '.gz' ) :
-                logger.warning( 'Unable to compress the file %s ' % self.__filename  )
-            size2 = os.path.getsize( self.__filename + '.gz' )
-            if not self.__silent : 
-                logger.info( 'GZIP compression %s: %.1f%%' % ( self.__filename, (size2*100.0)/size1 ) ) 
+        if not self.__opened:
+            return
 
-    ## gzip the file (``in-place'') 
-    def __in_place_gzip   ( self , filein ) :
+        shelve.Shelf.close(self)
+        self.__opened = False
+
+        if self.__remove and os.path.exists(self.__filename):
+            if not self.__silent:
+                logger.info('REMOVE: ', self.__filename)
+            os.remove(self.__filename)
+
+        if self.__gzip and os.path.exists(self.__filename):
+            # get the initial size 
+            size1 = os.path.getsize(self.__filename)
+            # gzip the file
+            self.__in_place_gzip(self.__filename)
+            #
+            if not os.path.exists(self.__filename + '.gz'):
+                logger.warning('Unable to compress the file %s ' % self.__filename)
+            size2 = os.path.getsize(self.__filename + '.gz')
+            if not self.__silent:
+                logger.info('GZIP compression %s: %.1f%%' % (self.__filename, (size2 * 100.0) / size1))
+
+    # gzip the file (``in-place'')
+    def __in_place_gzip(self, filein):
         """
         Gzip the file ``in-place''
         
@@ -197,23 +176,24 @@ class ZipShelf(shelve.Shelf):
         but it does not work properly for multiprocessing environemnt
         
         """
-        if os.path.exists ( filein + '.gz' ) : os.remove ( filein + '.gz' )
+        if os.path.exists(filein + '.gz'):
+            os.remove(filein + '.gz')
         #
         # gzip the file 
-        fileout = self._gzip ( filein )
+        fileout = self._gzip(filein)
         # 
-        if os.path.exists ( fileout ) :
+        if os.path.exists(fileout):
             # rename the temporary file 
-            shutil.move ( fileout , filein + '.gz' )
+            shutil.move(fileout, filein + '.gz')
             #
             import time
-            time.sleep( 3 )
+            time.sleep(3)
             #
             # remove the original
-            os.remove   ( filein ) 
+            os.remove(filein)
 
-    ## gunzip the file (``in-place'') 
-    def __in_place_gunzip   ( self , filein ) :
+    # gunzip the file (``in-place'')
+    def __in_place_gunzip(self, filein):
         """
         Gunzip the file ``in-place''
         
@@ -221,81 +201,81 @@ class ZipShelf(shelve.Shelf):
         but unfortunately it does not work properly for multithreaded environemnt
         
         """
-        #
-        filename = filein[:-3]            
-        if os.path.exists ( filename ) : os.remove ( filename )
-        #
+        filename = filein[:-3]
+        if os.path.exists(filename): os.remove(filename)
+
         # gunzip the file 
-        fileout = self._gunzip ( filein )
+        fileout = self._gunzip(filein)
         #        
-        if os.path.exists ( fileout ) :
+        if os.path.exists(fileout):
             # rename the temporary file 
-            shutil.move ( fileout , filename )
+            shutil.move(fileout, filename)
             #
             import time
-            time.sleep( 3 )
+            time.sleep(3)
             #
             # remove the original
-            os.remove   ( filein ) 
+            os.remove(filein)
 
-    ## gzip the file into temporary location, keep original
-    def _gzip   ( self , filein ) :
+    # gzip the file into temporary location, keep original
+    def _gzip(self, filein):
         """
         Gzip the file into temporary location, keep original
         """
-        if not os.path.exists  ( filein  ) :
-            raise NameError ( "GZIP: non existing file: " + filein )
-        #
-        fin  =      file ( filein  , 'r' )
-        #
-        import tempfile 
-        fd,fileout = tempfile.mkstemp ( prefix = 'tmp_' , suffix = '_zdb.gz' )
-        #
-        import gzip 
-        fout = gzip.open ( fileout , 'w' )
-        #
-        try : 
-            for all in fin : fout.write ( all )
+        if not os.path.exists(filein):
+            raise NameError("GZIP: non existing file: " + filein)
+
+        import tempfile, gzip
+
+        fin = file(filein, 'r')
+        fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb.gz')
+        fout = gzip.open(fileout, 'w')
+
+        try:
+            for all in fin:
+                fout.write(all)
         finally:
             fout.close()
-            fin .close()   
+            fin.close()
             import time
-            time.sleep( 3 ) 
+            time.sleep(3)
         return fileout
-        
-    ## gzip the file into temporary location, keep original
-    def _gunzip ( self , filein ) :
+
+    # gunzip the file into temporary location, keep original
+    def _gunzip(self, filein):
         """
         Gunzip the file into temporary location, keep original
         """
-        if not os.path.exists  ( filein  ) :
-            raise NameError ( "GUNZIP: non existing file: " + filein )
-        #
-        import gzip 
-        fin  = gzip.open ( filein  , 'r' )
-        #
-        import tempfile 
-        fd,fileout = tempfile.mkstemp ( prefix = 'tmp_' , suffix = '_zdb' )
-        fout = file ( fileout , 'w' )
-        #
-        try : 
-            for all in fin : fout.write ( all )
-        finally: 
+        if not os.path.exists(filein):
+            raise NameError("GUNZIP: non existing file: " + filein)
+
+        import gzip, tempfile
+
+        fin = gzip.open(filein, 'r')
+        fd, fileout = tempfile.mkstemp(prefix='tmp_', suffix='_zdb')
+        fout = file(fileout, 'w')
+
+        try:
+            for all in fin:
+                fout.write(all)
+        finally:
             fout.close()
-            fin .close()
+            fin.close()
             import time
-            time.sleep( 3 ) 
+            time.sleep(3)
         return fileout
 
-    #
-    ## some context manager functionality
-    # 
-    def __enter__ ( self      ) : return self 
-    def __exit__  ( self , *_ ) : self.close ()
-        
+    # some context manager functionality
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
 # =============================================================================
-## ``get-and-uncompress-item'' from dbase 
-def _zip_getitem (self, key):
+# ``get-and-uncompress-item'' from dbase
+def _zip_getitem(self, key):
     """
     ``get-and-uncompress-item'' from dbase 
     """
@@ -308,9 +288,10 @@ def _zip_getitem (self, key):
             self.cache[key] = value
     return value
 
+
 # =============================================================================
-## ``set-and-compress-item'' to dbase 
-def _zip_setitem ( self , key , value ) :
+# ``set-and-compress-item'' to dbase
+def _zip_setitem(self, key, value):
     """
     ``set-and-compress-item'' to dbase 
     """
@@ -319,21 +300,18 @@ def _zip_setitem ( self , key , value ) :
     f = BytesIO()
     p = Pickler(f, self._protocol)
     p.dump(value)
-    self.dict[key] = zlib.compress( f.getvalue(), self.compresslevel)
+    self.dict[key] = zlib.compress(f.getvalue(), self.compresslevel)
+
 
 ZipShelf.__getitem__ = _zip_getitem
 ZipShelf.__setitem__ = _zip_setitem
 
+
 # =============================================================================
-## helper finction to access ZipShelve data base#
-#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
-#  @date   2010-04-30
-def open ( filename                                   ,
-           mode          = 'c'                        ,
-           protocol      = HIGHEST_PROTOCOL           ,
-           compresslevel = zlib.Z_BEST_COMPRESSION    , 
-           writeback     = False                      ,
-           silent        = True                       ) : 
+# helper finction to access ZipShelve data base
+
+def open(filename, mode='c', protocol=HIGHEST_PROTOCOL, compress_level=zlib.Z_BEST_COMPRESSION,
+         writeback=False, silent=True):
     """
     Open a persistent dictionary for reading and writing.
     
@@ -346,61 +324,46 @@ def open ( filename                                   ,
     
     See the module's __doc__ string for an overview of the interface.
     """
-    
-    return ZipShelf ( filename      ,
-                      mode          ,
-                      protocol      ,
-                      compresslevel ,
-                      writeback     ,
-                      silent        )
 
-
+    return ZipShelf(filename, mode, protocol, compress_level, writeback, silent)
 
 # =============================================================================
-## TEMPORARY Zipped-version of ``shelve''-database
-#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
-#  @date   2015-10-31
+# TEMPORARY Zipped-version of ``shelve''-database
+
+
 class TmpZipShelf(ZipShelf):
     """
     TEMPORARY Zipped-version of ``shelve''-database     
-    """    
-    def __init__(
-        self                                   ,
-        protocol  = HIGHEST_PROTOCOL           , 
-        compress  = zlib.Z_BEST_COMPRESSION    ,
-        silent    = False                      ) :
+    """
 
-        ## create temporary file name 
+    def __init__(self, protocol=HIGHEST_PROTOCOL, compress=zlib.Z_BEST_COMPRESSION, silent=False):
+
+        # create temporary file name
         import tempfile
-        filename = tempfile.mktemp  ( suffix = '.zdb' )
-        
-        ZipShelf.__init__ ( self     ,  
-                            filename ,
-                            'n'      ,
-                            protocol ,
-                            compress , 
-                            False    , ## writeback 
-                            silent   ) 
-        
-    ## close and delete the file 
-    def close ( self )  :
-        ## close the shelve file
-        fname = self.filename() 
-        ZipShelf.close ( self )
-        ## delete the file 
-        if os.path.exists ( fname ) :
-            try :
-                os.unlink ( fname )
-            except : 
+        filename = tempfile.mktemp(suffix='.zdb')
+
+        ZipShelf.__init__(self, filename, 'n', protocol, compress, False, silent)
+
+        # close and delete the file
+
+    def close(self):
+        # close the shelve file
+        fname = self.filename()
+        ZipShelf.close(self)
+
+        # delete the file
+        if os.path.exists(fname):
+            try:
+                os.unlink(fname)
+            except:
                 pass
-            
+
+
 # =============================================================================
-## helper finction to open TEMPORARY ZipShelve data base#
-#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
-#  @date   2010-04-30
-def tmpdb ( protocol      = HIGHEST_PROTOCOL           ,
-            compresslevel = zlib.Z_BEST_COMPRESSION    , 
-            silent        = True                       ) : 
+# helper finction to open TEMPORARY ZipShelve data base
+
+
+def tmpdb(protocol=HIGHEST_PROTOCOL, compress_level=zlib.Z_BEST_COMPRESSION, silent=True):
     """
     Open a TEMPORARY persistent dictionary for reading and writing.
     
@@ -409,30 +372,21 @@ def tmpdb ( protocol      = HIGHEST_PROTOCOL           ,
     
     See the module's __doc__ string for an overview of the interface.
     """
-    return TmpZipShelf ( protocol      ,
-                         compresslevel ,
-                         silent        )
-    
+    return TmpZipShelf(protocol,compress_level, silent)
 
-# ============================================================================
-# logger.debug ( "Simple generic (c)Pickle-based ``zipped''-database")
-# =============================================================================
-## a bit more decorations for shelve  (optional)
-# import Ostap.shelve_ext
 
 # =============================================================================
-if '__main__' == __name__ :
-    
-    logger.info ( __file__  + '\n' ) 
-    logger.info ( 80*'*'   )
-    logger.info ( __doc__  )
-    logger.info ( 80*'*' )
-    logger.info ( ' Author  : %s' %         __author__    ) 
-    logger.info ( ' Version : %s' %         __version__   ) 
-    logger.info ( ' Date    : %s' %         __date__      )
-    logger.info ( ' Symbols : %s' %  list ( __all__     ) )
-    logger.info ( 80*'*' ) 
-    
+if '__main__' == __name__:
+    logger.info(__file__ + '\n')
+    logger.info(80 * '*')
+    logger.info(__doc__)
+    logger.info(80 * '*')
+    logger.info(' Author  : %s' % __author__)
+    logger.info(' Version : %s' % __version__)
+    logger.info(' Date    : %s' % __date__)
+    logger.info(' Symbols : %s' % list(__all__))
+    logger.info(80 * '*')
+
 # =============================================================================
 # The END 
 # =============================================================================

--- a/zipshelve.py
+++ b/zipshelve.py
@@ -1,0 +1,438 @@
+# Code modified from on: 
+# https://gitlab.cern.ch/lhcb/Analysis/blob/cc7f3b47bba84adab101ffa3be44480fff786ee4/Analysis/Ostap/python/Ostap/ZipShelve.py
+# Above code is Python2, tenatively modified to suit Python3
+# =============================================================================
+""" This is zip-version of shelve database.
+
+Keeping the same interface and functionlity as shelve data base,
+ZipShelf allows much more compact file size through the on-flight
+compression of the content
+
+However is contains several new features:
+
+ - Optionally it is possible to perform the compression
+   of the whole data base, that can be rathe useful fo data base
+   with large amout of keys 
+"""
+# =============================================================================
+__author__  = "Vanya BELYAEV Ivan.Belyaev@itep.ru"
+__date__    = "2010-04-30"
+__version__ = "$Revision$" 
+# =============================================================================
+
+__all__ = (
+    'ZipShelf' ,   ## The DB-itself
+    'open'     ,   ## helper function to hide the actual DB
+    'tmpdb'    ,   ## create TEMPORARY data base 
+    )
+
+try:
+    from cPickle import Pickler, Unpickler, HIGHEST_PROTOCOL
+except ImportError:
+    from  pickle import Pickler, Unpickler, HIGHEST_PROTOCOL 
+
+# ==============================================================================
+import os
+import zlib        ## use zlib to compress DB-content 
+import shelve      ## 
+import shutil
+from io import BytesIO 
+import logging as logger
+# =============================================================================
+
+
+class ZipShelf(shelve.Shelf):
+    """
+    Zipped-version of ``shelve''-database     
+    """    
+    def __init__(
+        self                                   ,
+        filename                               ,
+        mode      = 'c'                        , 
+        protocol  = HIGHEST_PROTOCOL           , 
+        compress  = zlib.Z_BEST_COMPRESSION    ,
+        writeback = False                      ,
+        silent    = False                      ) :
+
+        # expand the actual file name 
+        filename  = os.path.expandvars ( filename )
+        filename  = os.path.expanduser ( filename )
+        filename  = os.path.expandvars ( filename )
+        filename  = os.path.expandvars ( filename )
+
+        self.__gzip          = False 
+        self.__filename      = filename
+        self.__remove        = False
+        self.__silent        = silent
+        self.__opened        = False 
+
+        if not self.__silent :
+            logger.info ( 'Open DB: %s' % filename ) 
+        
+        if filename.rfind('.gz') + 3 == len(filename):
+            
+            if os.path.exists ( filename ) and 'r' == mode :
+                ## gunzip into temporary location
+                filename_ = self._gunzip ( filename ) 
+                if not os.path.exists ( filename_ ) :
+                    raise TypeError ( "Unable to gunzip properly: %s" % filename )
+                if not self.__silent : 
+                    size1 = os.path.getsize ( filename  ) 
+                    size2 = os.path.getsize ( filename_ )
+                    logger.info("GZIP uncompression %s: %.1f%%" %  ( filename , (size2*100.0)/size1 ) )
+                filename        = filename_ 
+                self.__filename = filename_
+                self.__remove   = True
+            elif os.path.exists ( filename ) and 'r' != mode :
+                ## unzip in place
+                filename_     = filename[:-3]
+                # remove existing file (if needed) 
+                if os.path.exists ( filename_ ) : os.remove ( filename_ )
+                size1 = os.path.getsize ( filename  ) 
+                # gunzip in place 
+                self.__in_place_gunzip  ( filename ) 
+                ##
+                if not os.path.exists ( filename_ ) :
+                    raise TypeError ( "Unable to gunzip properly: %s" % filename )
+                if not self.__silent : 
+                    size2 = os.path.getsize ( filename_ )
+                    logger.info("GZIP uncompression %s: %.1f%%" %  ( filename , (size2*100.0)/size1 ) ) 
+                filename        = filename_ 
+                self.__gzip     = True 
+                self.__filename = filename_
+                self.__remove   = False
+            else : 
+                ## 
+                filename        = filename[:-3]
+                self.__gzip     = True 
+                self.__filename = filename
+
+        import dbm
+        shelve.Shelf.__init__ (
+            self                                   ,
+            dbm.open ( self.__filename , mode ) ,
+            protocol                               ,
+            writeback                              )
+        
+        self.compresslevel = compress
+        self.__opened      = True
+
+    def filename ( self ) : return self.__filename
+    
+    ## destructor 
+    def __del__ ( self ) :
+        """
+        Destructor 
+        """
+        if self.__opened : self.close()  
+
+    ## list the avilable keys 
+    def __dir ( self , pattern = '' ) :
+        """
+        List the avilable keys (patterns included).
+        Pattern matching is performed accoriding to
+        fnmatch/glob/shell rules [it is not regex!] 
+        
+        >>> db = ...
+        >>> db.ls() ## all keys
+        >>> db.ls ('*MC*')
+        
+        """
+        keys_ = self.keys()
+        keys_.sort()
+        if pattern :
+            import fnmatch
+            _keys = [ k for k in keys_ if fnmatch.fnmatchcase ( k , pattern ) ]
+            keys_ = _keys
+        #
+        for key in keys_ : print(key)
+        
+    ## list the avilable keys 
+    def ls    ( self , pattern = '' ) :
+        """
+        List the avilable keys (patterns included).
+        Pattern matching is performed accoriding to
+        fnmatch/glob/shell rules [it is not regex!] 
+
+        >>> db = ...
+        >>> db.ls() ## all keys
+        >>> db.ls ('*MC*')        
+        
+        """
+        return self.__dir( pattern )
+        
+    ## cloze and gzip (if needed)
+    def close ( self ) :
+        """
+        Close the file (and gzip it if required) 
+        """
+        if not self.__opened : return 
+        ##
+        shelve.Shelf.close ( self )
+        self.__opened = False  
+        ##
+        if self.__remove and os.path.exists ( self.__filename ) :
+            if not self.__silent :
+                logger.info( 'REMOVE: ', self.__filename )
+            os.remove ( self.__filename )
+        ##
+        if self.__gzip and os.path.exists ( self.__filename ) :
+            # get the initial size 
+            size1 = os.path.getsize ( self.__filename )
+            # gzip the file
+            self.__in_place_gzip ( self.__filename ) 
+            #
+            if not os.path.exists ( self.__filename + '.gz' ) :
+                logger.warning( 'Unable to compress the file %s ' % self.__filename  )
+            size2 = os.path.getsize( self.__filename + '.gz' )
+            if not self.__silent : 
+                logger.info( 'GZIP compression %s: %.1f%%' % ( self.__filename, (size2*100.0)/size1 ) ) 
+
+    ## gzip the file (``in-place'') 
+    def __in_place_gzip   ( self , filein ) :
+        """
+        Gzip the file ``in-place''
+        
+        It is better to use here ``os.system'' or ``popen''-family,
+        but it does not work properly for multiprocessing environemnt
+        
+        """
+        if os.path.exists ( filein + '.gz' ) : os.remove ( filein + '.gz' )
+        #
+        # gzip the file 
+        fileout = self._gzip ( filein )
+        # 
+        if os.path.exists ( fileout ) :
+            # rename the temporary file 
+            shutil.move ( fileout , filein + '.gz' )
+            #
+            import time
+            time.sleep( 3 )
+            #
+            # remove the original
+            os.remove   ( filein ) 
+
+    ## gunzip the file (``in-place'') 
+    def __in_place_gunzip   ( self , filein ) :
+        """
+        Gunzip the file ``in-place''
+        
+        It is better to use here ``os.system'' or ``popen''-family,
+        but unfortunately it does not work properly for multithreaded environemnt
+        
+        """
+        #
+        filename = filein[:-3]            
+        if os.path.exists ( filename ) : os.remove ( filename )
+        #
+        # gunzip the file 
+        fileout = self._gunzip ( filein )
+        #        
+        if os.path.exists ( fileout ) :
+            # rename the temporary file 
+            shutil.move ( fileout , filename )
+            #
+            import time
+            time.sleep( 3 )
+            #
+            # remove the original
+            os.remove   ( filein ) 
+
+    ## gzip the file into temporary location, keep original
+    def _gzip   ( self , filein ) :
+        """
+        Gzip the file into temporary location, keep original
+        """
+        if not os.path.exists  ( filein  ) :
+            raise NameError ( "GZIP: non existing file: " + filein )
+        #
+        fin  =      file ( filein  , 'r' )
+        #
+        import tempfile 
+        fd,fileout = tempfile.mkstemp ( prefix = 'tmp_' , suffix = '_zdb.gz' )
+        #
+        import gzip 
+        fout = gzip.open ( fileout , 'w' )
+        #
+        try : 
+            for all in fin : fout.write ( all )
+        finally:
+            fout.close()
+            fin .close()   
+            import time
+            time.sleep( 3 ) 
+        return fileout
+        
+    ## gzip the file into temporary location, keep original
+    def _gunzip ( self , filein ) :
+        """
+        Gunzip the file into temporary location, keep original
+        """
+        if not os.path.exists  ( filein  ) :
+            raise NameError ( "GUNZIP: non existing file: " + filein )
+        #
+        import gzip 
+        fin  = gzip.open ( filein  , 'r' )
+        #
+        import tempfile 
+        fd,fileout = tempfile.mkstemp ( prefix = 'tmp_' , suffix = '_zdb' )
+        fout = file ( fileout , 'w' )
+        #
+        try : 
+            for all in fin : fout.write ( all )
+        finally: 
+            fout.close()
+            fin .close()
+            import time
+            time.sleep( 3 ) 
+        return fileout
+
+    #
+    ## some context manager functionality
+    # 
+    def __enter__ ( self      ) : return self 
+    def __exit__  ( self , *_ ) : self.close ()
+        
+# =============================================================================
+## ``get-and-uncompress-item'' from dbase 
+def _zip_getitem (self, key):
+    """
+    ``get-and-uncompress-item'' from dbase 
+    """
+    try:
+        value = self.cache[key]
+    except KeyError:
+        f = BytesIO(zlib.decompress(self.dict[key]))
+        value = Unpickler(f).load()
+        if self.writeback:
+            self.cache[key] = value
+    return value
+
+# =============================================================================
+## ``set-and-compress-item'' to dbase 
+def _zip_setitem ( self , key , value ) :
+    """
+    ``set-and-compress-item'' to dbase 
+    """
+    if self.writeback:
+        self.cache[key] = value
+    f = BytesIO()
+    p = Pickler(f, self._protocol)
+    p.dump(value)
+    self.dict[key] = zlib.compress( f.getvalue(), self.compresslevel)
+
+ZipShelf.__getitem__ = _zip_getitem
+ZipShelf.__setitem__ = _zip_setitem
+
+# =============================================================================
+## helper finction to access ZipShelve data base#
+#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
+#  @date   2010-04-30
+def open ( filename                                   ,
+           mode          = 'c'                        ,
+           protocol      = HIGHEST_PROTOCOL           ,
+           compresslevel = zlib.Z_BEST_COMPRESSION    , 
+           writeback     = False                      ,
+           silent        = True                       ) : 
+    """
+    Open a persistent dictionary for reading and writing.
+    
+    The filename parameter is the base filename for the underlying
+    database.  As a side-effect, an extension may be added to the
+    filename and more than one file may be created.  The optional flag
+    parameter has the same interpretation as the flag parameter of
+    anydbm.open(). The optional protocol parameter specifies the
+    version of the pickle protocol (0, 1, or 2).
+    
+    See the module's __doc__ string for an overview of the interface.
+    """
+    
+    return ZipShelf ( filename      ,
+                      mode          ,
+                      protocol      ,
+                      compresslevel ,
+                      writeback     ,
+                      silent        )
+
+
+
+# =============================================================================
+## TEMPORARY Zipped-version of ``shelve''-database
+#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
+#  @date   2015-10-31
+class TmpZipShelf(ZipShelf):
+    """
+    TEMPORARY Zipped-version of ``shelve''-database     
+    """    
+    def __init__(
+        self                                   ,
+        protocol  = HIGHEST_PROTOCOL           , 
+        compress  = zlib.Z_BEST_COMPRESSION    ,
+        silent    = False                      ) :
+
+        ## create temporary file name 
+        import tempfile
+        filename = tempfile.mktemp  ( suffix = '.zdb' )
+        
+        ZipShelf.__init__ ( self     ,  
+                            filename ,
+                            'n'      ,
+                            protocol ,
+                            compress , 
+                            False    , ## writeback 
+                            silent   ) 
+        
+    ## close and delete the file 
+    def close ( self )  :
+        ## close the shelve file
+        fname = self.filename() 
+        ZipShelf.close ( self )
+        ## delete the file 
+        if os.path.exists ( fname ) :
+            try :
+                os.unlink ( fname )
+            except : 
+                pass
+            
+# =============================================================================
+## helper finction to open TEMPORARY ZipShelve data base#
+#  @author Vanya BELYAEV Ivan.Belyaev@cern.ch
+#  @date   2010-04-30
+def tmpdb ( protocol      = HIGHEST_PROTOCOL           ,
+            compresslevel = zlib.Z_BEST_COMPRESSION    , 
+            silent        = True                       ) : 
+    """
+    Open a TEMPORARY persistent dictionary for reading and writing.
+    
+    The optional protocol parameter specifies the
+    version of the pickle protocol (0, 1, or 2).
+    
+    See the module's __doc__ string for an overview of the interface.
+    """
+    return TmpZipShelf ( protocol      ,
+                         compresslevel ,
+                         silent        )
+    
+
+# ============================================================================
+# logger.debug ( "Simple generic (c)Pickle-based ``zipped''-database")
+# =============================================================================
+## a bit more decorations for shelve  (optional)
+# import Ostap.shelve_ext
+
+# =============================================================================
+if '__main__' == __name__ :
+    
+    logger.info ( __file__  + '\n' ) 
+    logger.info ( 80*'*'   )
+    logger.info ( __doc__  )
+    logger.info ( 80*'*' )
+    logger.info ( ' Author  : %s' %         __author__    ) 
+    logger.info ( ' Version : %s' %         __version__   ) 
+    logger.info ( ' Date    : %s' %         __date__      )
+    logger.info ( ' Symbols : %s' %  list ( __all__     ) )
+    logger.info ( 80*'*' ) 
+    
+# =============================================================================
+# The END 
+# =============================================================================


### PR DESCRIPTION
Reviewer(s), please try to break this branch before approving merge-request. See [issue](https://github.com/iabraham/pyhcp/issues/3) for details. In short, legacy code was modified/updated and  used to compress [shelve](https://docs.python.org/3/library/shelve.html) files. 

Suggested actions:

- Run `automate.py` on a fresh Anaconda environment to generate the shelve files in `HCP_1200` folder. 
- Run suggested code in `HCP_1200/README.md` to ensure generated binaries are accessible. 
- Copy over generated files to _new folder_ **outside** repo along with `zipshelve.py` from the repo.
- Create a `test.py` file in the new folder. In that file, import `zipshelve` and run all sorts of crazy tests on the binaries to see what can be made broken.
